### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,8 @@ npx @modelcontextprotocol/inspector -e VM_URL=http://127.0.0.1:8428  node src/in
 | `label`   | `string` | Label name to get values for | ✅        |
 
 ---
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/yincongcyincong-victoriametrics-mcp-server).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/yincongcyincong-victoriametrics-mcp-server).